### PR TITLE
patching ActiveAdmin::FormBuilder to provide nested forms support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,9 +6,13 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
+inherit_gem:
+  spbtv_code_style: .rubocop.yml
+
 AllCops:
   Exclude:
     - spec/dummy/**/*
+    - spec/templates/*
 
 # Configuration parameters: AllowURI, URISchemes.
 Metrics/LineLength:

--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ group :test do
   gem 'launchy', '~> 2.4.3'
   gem 'database_cleaner', '~> 1.5.1'
   gem 'capybara', '~> 2.5.0'
+  gem 'poltergeist'
 
   gem 'codeclimate-test-reporter', '~> 0.4.8', require: nil
 end

--- a/activeadmin-reform.gemspec
+++ b/activeadmin-reform.gemspec
@@ -20,9 +20,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'rails', '>= 3.2'
   spec.add_dependency 'disposable', '>= 0.2.0'
-  spec.add_dependency 'reform', '>= 2.0'
+  spec.add_dependency 'reform', '~> 2.2.1'
+  spec.add_dependency 'reform-rails'
   spec.add_development_dependency 'bundler', '~> 1.10'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.4'
-  spec.add_development_dependency 'rubocop', '~> 0.34.2'
+  spec.add_development_dependency 'spbtv_code_style', '~> 1.4.1'
 end

--- a/lib/active_admin/reform.rb
+++ b/lib/active_admin/reform.rb
@@ -1,6 +1,11 @@
+require 'reform'
+require 'reform/rails'
+
 module ActiveAdmin
   #
   module Reform
     require_relative 'reform/engine'
+    require_relative 'reform/active_record'
+    require_relative 'reform/form_builder'
   end
 end

--- a/lib/active_admin/reform/active_record.rb
+++ b/lib/active_admin/reform/active_record.rb
@@ -1,0 +1,29 @@
+require 'reform'
+require 'reform/form/active_record'
+require 'reform/form/active_model/model_reflections'
+
+module ActiveAdmin
+  module Reform
+    # Module that prepares the Reform::Form for use in activeadmin
+    module ActiveRecord
+      extend ActiveSupport::Concern
+
+      delegate :new_record?, to: :model
+
+      included do
+        include ::Reform::Form::ModelReflections
+        include ::Reform::Form::ActiveRecord
+      end
+
+      # Those methods are being used by activeadmin and are proxied to an inferred from name model
+      module ClassMethods
+        delegate :human_attribute_name, to: :model_class
+        delegate :lookup_ancestors, to: :model_class
+
+        def model_class
+          @model_class ||= model_name.to_s.constantize
+        end
+      end
+    end
+  end
+end

--- a/lib/active_admin/reform/engine.rb
+++ b/lib/active_admin/reform/engine.rb
@@ -10,6 +10,8 @@ module ActiveAdmin
         require 'active_admin'
         require_relative 'dsl'
         require_relative 'forms'
+
+        ActiveAdmin::FormBuilder.prepend FormBuilder
       end
     end
   end

--- a/lib/active_admin/reform/form_builder.rb
+++ b/lib/active_admin/reform/form_builder.rb
@@ -1,0 +1,47 @@
+require 'reform/form/active_model/model_reflections'
+
+module ActiveAdmin
+  module Reform
+    # Patching ActiveAdmin::FormBuilder#js_for_has_many to provide nested forms support
+    # https://github.com/activeadmin/activeadmin/blob/539fa4b/lib/active_admin/form_builder.rb#L123
+    module FormBuilder
+      private
+
+      # Capture the ADD JS
+      # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
+      def js_for_has_many(assoc, form_block, template, new_record, class_string)
+        assoc_reflection = object.class.reflect_on_association assoc
+        assoc_name       = assoc_reflection.klass.model_name
+        placeholder      = "NEW_#{assoc_name.to_s.underscore.upcase.gsub(%r{/}, '_')}_RECORD"
+        opts = {
+          for: [assoc, nested_object(assoc)],
+          class: class_string,
+          for_options: { child_index: placeholder },
+        }
+        html = template.capture { inputs_for_nested_attributes opts, &form_block }
+        text = new_record.is_a?(String) ? new_record : I18n.t('active_admin.has_many_new', model: assoc_name.human)
+
+        template.link_to text, '#', class: 'button has_many_add', data: {
+          html: CGI.escapeHTML(html).html_safe, placeholder: placeholder
+        }
+      end
+      # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
+
+      def nested_form_class(assoc)
+        if object.is_a?(::Reform::Form) && (property = object.class.definitions[assoc.to_s]) &&
+           (nested_form = property[:nested]) < ::Reform::Form
+          nested_form
+        end
+      end
+
+      def nested_object(assoc)
+        assoc_reflection = object.class.reflect_on_association assoc
+        if (nested_form = nested_form_class(assoc))
+          nested_form.new(assoc_reflection.klass.new).tap(&:prepopulate!)
+        else
+          assoc_reflection.klass.new
+        end
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,9 @@ ActiveAdmin.application.current_user_method = false
 require 'rspec/rails'
 require 'capybara/rails'
 require 'capybara/rspec'
+require 'capybara/poltergeist'
+
+Capybara.javascript_driver = :poltergeist
 
 RSpec.configure do |config|
   config.use_transactional_fixtures = false
@@ -41,3 +44,6 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 end
+
+require 'reform/form/active_model/validations'
+Reform::Form.include Reform::Form::ActiveModel::Validations

--- a/spec/support/rails_template.rb
+++ b/spec/support/rails_template.rb
@@ -10,9 +10,6 @@ environment <<-RUBY
   $LOAD_PATH.unshift('#{File.expand_path(File.join(File.dirname(__FILE__), '..', '..', 'lib'))}')
 RUBY
 
-copy_file(File.expand_path('../../templates/author_form.rb', __FILE__), 'app/models/author_form.rb')
-copy_file(File.expand_path('../../templates/commenter_form.rb', __FILE__), 'app/models/commenter_form.rb')
-
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 
 # Setup a root path for devise
@@ -26,8 +23,17 @@ do_after_bundle = lambda do
   inject_into_file 'app/models/author.rb', <<-RUBY, after: "Base\n"
     validates :name, length: { minimum: 2 }, allow_nil: true
   RUBY
+  generate :model, 'post text --no-test-framework'
+  generate :model, 'comment post:references text --no-test-framework'
+  inject_into_file 'app/models/post.rb', <<-RUBY, after: "Base\n"
+    has_many :comments
+  RUBY
   generate :'active_admin:install --skip-users'
   rake 'db:migrate'
+
+  copy_file(File.expand_path('../../templates/author_form.rb', __FILE__), 'app/models/author_form.rb')
+  copy_file(File.expand_path('../../templates/commenter_form.rb', __FILE__), 'app/models/commenter_form.rb')
+  copy_file(File.expand_path('../../templates/post_form.rb', __FILE__), 'app/models/post_form.rb')
 end
 
 if Rails.respond_to?(:gem_version) && Rails.gem_version >= Gem::Version.new('4.2')

--- a/spec/templates/author_form.rb
+++ b/spec/templates/author_form.rb
@@ -1,5 +1,5 @@
-require 'reform'
-
 class AuthorForm < Reform::Form
+  include ActiveAdmin::Reform::ActiveRecord
+
   property :last_name, validates: { presence: true }
 end

--- a/spec/templates/commenter_form.rb
+++ b/spec/templates/commenter_form.rb
@@ -1,6 +1,8 @@
-require 'reform'
-
 class CommenterForm < Reform::Form
+  include ActiveAdmin::Reform::ActiveRecord
+
+  model :author
+
   property :surname, virtual: true, prepopulator: ->(_) { self.surname = model.last_name }
 
   def sync

--- a/spec/templates/post_form.rb
+++ b/spec/templates/post_form.rb
@@ -1,0 +1,12 @@
+class PostForm < Reform::Form
+  include ActiveAdmin::Reform::ActiveRecord
+
+  property :text, prepopulator: ->(*) { self.text = 'Initial post text' }
+
+  collection :comments, populate_if_empty: Comment do
+    include ActiveAdmin::Reform::ActiveRecord
+    model :comment
+
+    property :text, prepopulator: ->(*) { self.text = 'Initial comment text' }
+  end
+end


### PR DESCRIPTION
- Обновил реформ
- Запатчил метод activeadmin
- Вынес `Concerns::ModelReflections`, как `ActiveAdmin::Reform::ActiveRecord`.
  Вложенные формы заработали. Единственное, что поменялось, это `model_name` у форм с именем, отличающимся от имени класса. Теперь оно такое же, как и у формы с нормальным именем.
  Еще сломалась небольшая штука из-за обновления реформа. Поправил в пулл реквесте -
  https://github.com/apotonick/representable/pull/191
