### PR TITLE
adapted the form object interface in ActiveAdmin::Reform::ActiveRecord for ActiveAdmin::Resource::DataAccess

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--require spec_helper

--- a/README.md
+++ b/README.md
@@ -30,12 +30,14 @@ Or install it yourself as:
 
 ## Usage
 
-Define your from object
+Define your form object and include our mixin (`ActiveAdmin::Reform::ActiveRecord`) into it:
  
 ```ruby
 require 'reform'
 
 class AuthorForm < Reform::Form
+  include ActiveAdmin::Reform::ActiveRecord
+
   property :last_name, validates: { presence: true }
   property :name
 end

--- a/lib/active_admin/reform/active_record.rb
+++ b/lib/active_admin/reform/active_record.rb
@@ -10,10 +10,18 @@ module ActiveAdmin
 
       delegate :new_record?, to: :model
 
-      def save_model
-        super.tap do
+      # @return [Boolean]
+      # Used here - https://github.com/activeadmin/activeadmin/blob/487f976/lib/active_admin/resource_controller/data_access.rb#L160
+      def save
+        validate({}) && super.tap do
           errors.merge!(model.errors, [])
         end
+      end
+
+      # @param attributes [Hash]
+      # Used here - https://github.com/activeadmin/activeadmin/blob/487f976/lib/active_admin/resource_controller/data_access.rb#L301
+      def assign_attributes(attributes)
+        deserialize(attributes)
       end
 
       included do

--- a/lib/active_admin/reform/resource_controller/data_access.rb
+++ b/lib/active_admin/reform/resource_controller/data_access.rb
@@ -16,31 +16,6 @@ module ActiveAdmin
         def apply_decorations(_resource)
           apply_form(super)
         end
-
-        # @param resource [ActiveRecord::Base, Reform::Form]
-        # @param attributes [(Hash)]
-        # @return [ActiveRecord::Base, Reform::Form]
-        def assign_attributes(resource, attributes)
-          if resource.is_a?(::Reform::Form)
-            resource.validate(*attributes) unless %w(new edit).include?(action_name)
-            resource
-          else
-            super
-          end
-        end
-
-        # Calls all the appropriate callbacks and then saves the new resource.
-        #
-        # @param [ActiveRecord::Base] object The new resource to save
-        #
-        # @return [void]
-        def save_resource(object)
-          if resource.is_a?(::Reform::Form)
-            super unless object.errors.any?
-          else
-            super
-          end
-        end
       end
 
       ::ActiveAdmin::ResourceController.send(:include, DataAccess)

--- a/spec/active_record_spec.rb
+++ b/spec/active_record_spec.rb
@@ -1,0 +1,31 @@
+RSpec.describe ActiveAdmin::Reform::ActiveRecord do
+  describe '#save' do
+    subject(:save) do
+      form.assign_attributes(attributes)
+      form.save
+    end
+    let(:form) { PostForm.new(post) }
+    let(:post) { Post.new }
+
+    context 'model validation fails' do
+      let(:attributes) { { text: '' } }
+
+      it do
+        expect { save }.not_to change(Post, :count)
+        expect(save).to be_falsey
+        expect(form.errors).to be_any
+        expect(form.errors[:text]).to contain_exactly("can't be blank")
+      end
+    end
+
+    context 'model validation succeeds' do
+      let(:attributes) { { text: 'text' } }
+
+      it do
+        expect { save }.to change(Post, :count)
+        expect(save).to be_truthy
+        expect(form.errors).not_to be_any
+      end
+    end
+  end
+end


### PR DESCRIPTION
Instead of patching `ActiveAdmin::Resource::DataAccess` we adapt the form interface for it.

https://github.com/bolshakov/activeadmin-reform/issues/24
